### PR TITLE
Removed common crypto module

### DIFF
--- a/CommonCrypto/module.modulemap
+++ b/CommonCrypto/module.modulemap
@@ -1,4 +1,0 @@
-module CommonCrypto [system] {
-    header "shim.h"
-    export *
-}

--- a/CommonCrypto/shim.h
+++ b/CommonCrypto/shim.h
@@ -1,1 +1,0 @@
-#include <CommonCrypto/CommonCrypto.h>

--- a/JWT.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JWT.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
In Swift 4.0. CommonCrypto is already part of the framework.